### PR TITLE
test(order): add type tests for order state machine

### DIFF
--- a/apps/order-service/src/app/order-workflow/domain/entities/order/order.type-tests.ts
+++ b/apps/order-service/src/app/order-workflow/domain/entities/order/order.type-tests.ts
@@ -1,0 +1,51 @@
+import { OrderActions, OrderStates } from './order.enum';
+import { StateRegistry } from './order.state';
+import {
+  LegalOutcome,
+  IllegalOutcome,
+  NextActions,
+} from './order.type';
+
+// Completed is a terminal state and exposes no next actions.
+// @ts-expect-error Terminal states should not accept any action
+const completedHasAction: NextActions<OrderStates.Completed> = OrderActions.Cancel;
+
+// Illegal actions against terminal states yield IllegalOutcome.
+type CompletedState = InstanceType<(typeof StateRegistry)[OrderStates.Completed]>;
+const completedState = {} as CompletedState;
+const completedResult = completedState.handle(OrderActions.Cancel);
+const completedIsIllegal: IllegalOutcome = completedResult;
+// @ts-expect-error Completed state cannot produce a legal outcome
+const completedIsLegal: LegalOutcome<
+  OrderStates.Completed,
+  NextActions<OrderStates.Completed>
+> = completedResult;
+
+// PendingCompletion has at least one valid action and should return legal outcomes.
+type PendingCompletionState = InstanceType<
+  (typeof StateRegistry)[OrderStates.PendingCompletion]
+>;
+const pendingCompletionState = {} as PendingCompletionState;
+const validAction = null as any as NextActions<OrderStates.PendingCompletion>;
+const pendingLegal = pendingCompletionState.handle(validAction);
+const pendingIsLegal: LegalOutcome<
+  OrderStates.PendingCompletion,
+  NextActions<OrderStates.PendingCompletion>
+> = pendingLegal;
+// @ts-expect-error Legal outcome is not assignable to IllegalOutcome
+const pendingLegalIsIllegal: IllegalOutcome = pendingLegal;
+
+// PendingCompletion should reject invalid actions.
+const invalidAction = null as any as Exclude<
+  OrderActions,
+  NextActions<OrderStates.PendingCompletion>
+>;
+const pendingIllegal = pendingCompletionState.handle(invalidAction);
+const pendingIsIllegal: IllegalOutcome = pendingIllegal;
+// @ts-expect-error Illegal outcome is not assignable to LegalOutcome
+const pendingIllegalIsLegal: LegalOutcome<
+  OrderStates.PendingCompletion,
+  NextActions<OrderStates.PendingCompletion>
+> = pendingIllegal;
+
+export {};


### PR DESCRIPTION
## Summary
- add compile-time tests for order state machine covering terminal and non-terminal states
- ensure invalid actions on terminal states yield IllegalOutcome
- verify PendingCompletion distinguishes between legal and illegal actions

## Testing
- `npx tsc -p apps/order-service/tsconfig.app.json --noEmit`
- `npx jest -c apps/order-service/jest.config.ts --runInBand` *(fails: Could not find a working container runtime strategy)*

------
https://chatgpt.com/codex/tasks/task_e_68bb55c1ffec832ea3a0ba958109600d