### PR TITLE
fix(order-service): correct request cooldown config import

### DIFF
--- a/apps/order-service/src/app/order-workflow/infra/di/order-workflow.module.ts
+++ b/apps/order-service/src/app/order-workflow/infra/di/order-workflow.module.ts
@@ -26,6 +26,7 @@ import { WorkshopInvitationResponseService } from 'apps/order-service/src/app/or
 import { MockAuthGuard } from 'apps/order-service/src/app/order-workflow/infra/auth/guards/mock-auth.guard';
 import { OrderHttpJwtGuard } from 'apps/order-service/src/app/order-workflow/infra/auth/guards/order-http-jwt.guard';
 import { JwtStrategy } from 'apps/order-service/src/app/order-workflow/infra/auth/strategies/jwt.strategy';
+import { OrderAuthGuardProxy } from 'apps/order-service/src/app/order-workflow/infra/auth/proxy/auth-token-proxy';
 import { orderWorkflowKafkaConfig } from 'apps/order-service/src/app/order-workflow/infra/config/kafka.config';
 import { OrderWorkflowTypeOrmOptions } from 'apps/order-service/src/app/order-workflow/infra/config/typeorm-config';
 import { orderWorkflowWinstonConfig } from 'apps/order-service/src/app/order-workflow/infra/config/winston.config';

--- a/apps/order-service/src/infra/request-cooldown/request-cooldown-config.token.ts
+++ b/apps/order-service/src/infra/request-cooldown/request-cooldown-config.token.ts
@@ -1,4 +1,4 @@
-import type { RequestCooldownConfig } from '../../../../../configs/request-cooldown.config';
+import type { RequestCooldownConfig } from '../config/request-cooldown.config';
 
 export const REQUEST_COOLDOWN_CONFIG = 'REQUEST_COOLDOWN_CONFIG';
 


### PR DESCRIPTION
## Summary
- fix request cooldown token import path to use infra config

## Testing
- `npm test libs/auth -- --passWithNoTests`
- `npm test libs/error-handling/registries/order -- --passWithNoTests`
- `npm test libs/persistence -- --passWithNoTests` *(fails: Cannot find module 'error-handling/error-core')*
- `npm test apps/order-service -- --passWithNoTests` *(fails: Cannot find modules in test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb8fc2560832e8ca2dbc703ac3266