### PR TITLE
fix(order-service): import auth proxy

### DIFF
--- a/apps/order-service/src/app/order-workflow/infra/di/order-workflow.module.ts
+++ b/apps/order-service/src/app/order-workflow/infra/di/order-workflow.module.ts
@@ -26,6 +26,7 @@ import { WorkshopInvitationResponseService } from 'apps/order-service/src/app/or
 import { MockAuthGuard } from 'apps/order-service/src/app/order-workflow/infra/auth/guards/mock-auth.guard';
 import { OrderHttpJwtGuard } from 'apps/order-service/src/app/order-workflow/infra/auth/guards/order-http-jwt.guard';
 import { JwtStrategy } from 'apps/order-service/src/app/order-workflow/infra/auth/strategies/jwt.strategy';
+import { OrderAuthGuardProxy } from 'apps/order-service/src/app/order-workflow/infra/auth/proxy/auth-token-proxy';
 import { orderWorkflowKafkaConfig } from 'apps/order-service/src/app/order-workflow/infra/config/kafka.config';
 import { OrderWorkflowTypeOrmOptions } from 'apps/order-service/src/app/order-workflow/infra/config/typeorm-config';
 import { orderWorkflowWinstonConfig } from 'apps/order-service/src/app/order-workflow/infra/config/winston.config';


### PR DESCRIPTION
## Summary
- import `OrderAuthGuardProxy` into order workflow module to resolve runtime ReferenceError

## Testing
- `npm test apps/order-service -- --passWithNoTests` *(fails: Cannot find module 'contracts' and other modules in test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68bdea4dc3f8832ea2c6427c37e53833