### PR TITLE
feat(auth): enforce actor roles per route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md
 .jscpd.json
+.rdb

--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,4 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md
 .jscpd.json
-.rdb
+rdata/dump.rdb

--- a/apps/bonus-service/src/main.ts
+++ b/apps/bonus-service/src/main.ts
@@ -108,7 +108,7 @@ async function bootstrap() {
 
   // Graceful shutdown on signals
   const shutdown = async (signal: string) => {
-    console.log(`\nReceived ${signal}. Shutting down...`);
+    console.warn({message: `\nReceived ${signal}. Shutting down...}`});
     process.exit(0);
   };
   process.on('SIGINT', () => shutdown('SIGINT'));
@@ -116,6 +116,6 @@ async function bootstrap() {
 }
 
 bootstrap().catch((err) => {
-  console.error('Fatal on bootstrap:', err);
+  console.error({ message: 'Fatal on bootstrap:', err });
   process.exit(1);
 });

--- a/apps/order-service-e2e/src/support/global-setup.ts
+++ b/apps/order-service-e2e/src/support/global-setup.ts
@@ -88,7 +88,7 @@ module.exports = async function () {
     );
   }
 
-  await new Promise((r) => setTimeout(r, 8000))
+  await new Promise((r) => setTimeout(r, 15_000))
 
   // Spawn app with the correct env 
   const app = spawn('node', [entry], {

--- a/apps/order-service/src/app/order-workflow/adapters/inbound/http/order-confirm-completion.controller.ts
+++ b/apps/order-service/src/app/order-workflow/adapters/inbound/http/order-confirm-completion.controller.ts
@@ -13,6 +13,7 @@ import { OrderComfirmCompletionService } from 'apps/order-service/src/app/order-
 import { OrderInitDtoV1, OrderConfirmCompletionDtoV1 } from 'contracts';
 import { validator } from 'adapter';
 import { OrderAuthGuardProxy } from 'apps/order-service/src/app/order-workflow/infra/auth/proxy/auth-token-proxy';
+import { ActorName, ActorNames } from 'auth';
 
 @ApiTags('Order workflow')
 @ApiBearerAuth('JWT')
@@ -21,6 +22,7 @@ export class OrderComfirmCompletionController {
   constructor(private readonly service: OrderComfirmCompletionService) {}
 
     @Post()
+    @ActorNames(ActorName.Commissioner)
     @UseGuards(OrderAuthGuardProxy)
     @UsePipes(new ValidationPipe(validator))
     @HttpCode(200)

--- a/apps/order-service/src/app/order-workflow/adapters/inbound/http/order-init.controller.ts
+++ b/apps/order-service/src/app/order-workflow/adapters/inbound/http/order-init.controller.ts
@@ -23,6 +23,7 @@ import { OrderInitResultDto } from 'contracts';
 import { OrderInitDtoV1, OrderInitPaths } from 'contracts';
 import { validator } from 'adapter';
 import { OrderAuthGuardProxy } from 'apps/order-service/src/app/order-workflow/infra/auth/proxy/auth-token-proxy';
+import { ActorName, ActorNames } from 'auth';
 
 
 @ApiTags('Order workflow')
@@ -32,6 +33,7 @@ export class OrderInitController {
   constructor(private readonly orderInitService: OrderInitService) {}
 
   @Post()
+  @ActorNames(ActorName.Commissioner)
   @UseGuards(OrderAuthGuardProxy)
   @UsePipes(new ValidationPipe(validator))
   @ApiOperation({

--- a/apps/order-service/src/app/order-workflow/adapters/inbound/http/order.cancel.controller.ts
+++ b/apps/order-service/src/app/order-workflow/adapters/inbound/http/order.cancel.controller.ts
@@ -21,6 +21,7 @@ import { OrderCancelService } from 'apps/order-service/src/app/order-workflow/ap
 import { OrderCancelDtoV1, OrderInitDtoV1 } from 'contracts';
 import { validator } from 'adapter';
 import { OrderAuthGuardProxy } from 'apps/order-service/src/app/order-workflow/infra/auth/proxy/auth-token-proxy';
+import { ActorName, ActorNames } from 'auth';
 
 @ApiTags('Order workflow')
 @ApiBearerAuth('JWT')
@@ -29,6 +30,7 @@ export class OrderCancelController {
   constructor(private readonly orderCancelService: OrderCancelService) {}
 
     @Post()
+    @ActorNames(ActorName.Commissioner)
     @UseGuards(OrderAuthGuardProxy)
     @UsePipes(new ValidationPipe(validator))
     @HttpCode(200)

--- a/apps/order-service/src/app/order-workflow/adapters/inbound/http/stage-completion.controller.ts
+++ b/apps/order-service/src/app/order-workflow/adapters/inbound/http/stage-completion.controller.ts
@@ -26,6 +26,7 @@ import {
 } from 'contracts';
 import { validator } from 'adapter';
 import { OrderAuthGuardProxy } from 'apps/order-service/src/app/order-workflow/infra/auth/proxy/auth-token-proxy';
+import { ActorName, ActorNames } from 'auth';
 
 @ApiTags('Order workflow')
 @ApiBearerAuth('JWT')
@@ -36,6 +37,7 @@ export class StageCompletionController {
   ) {}
 
   @Post(StageCompletionPaths.Mark)
+  @ActorNames(ActorName.Workshop)
   @UseGuards(OrderAuthGuardProxy)
   @UsePipes(new ValidationPipe(validator))
   @ApiOperation({
@@ -63,6 +65,7 @@ export class StageCompletionController {
   }
 
   @Post(StageCompletionPaths.Confirm)
+  @ActorNames(ActorName.Commissioner)
   @UseGuards(OrderAuthGuardProxy)
   @UsePipes(new ValidationPipe(validator))
   @ApiOperation({

--- a/apps/order-service/src/app/order-workflow/adapters/inbound/http/workshop-invitation-response.controller.ts
+++ b/apps/order-service/src/app/order-workflow/adapters/inbound/http/workshop-invitation-response.controller.ts
@@ -27,6 +27,7 @@ import {
 } from 'contracts';
 import { validator } from 'adapter';
 import { OrderAuthGuardProxy } from 'apps/order-service/src/app/order-workflow/infra/auth/proxy/auth-token-proxy';
+import { ActorName, ActorNames } from 'auth';
 
 @ApiTags('Order workflow')
 @ApiBearerAuth('JWT')
@@ -37,6 +38,7 @@ export class WorkshopInvitationResponseController {
   ) {}
 
   @Post(WorkshopInvitationResponsePaths.Accept)
+  @ActorNames(ActorName.Workshop)
   @UseGuards(OrderAuthGuardProxy)
   @UsePipes(new ValidationPipe(validator))
   @ApiOperation({
@@ -75,6 +77,7 @@ export class WorkshopInvitationResponseController {
   }
 
   @Post(WorkshopInvitationResponsePaths.Decline)
+  @ActorNames(ActorName.Workshop)
   @UseGuards(OrderAuthGuardProxy)
   @UsePipes(new ValidationPipe(validator))
   @ApiOperation({

--- a/apps/order-service/src/app/order-workflow/infra/auth/guards/order-http-jwt.guard.ts
+++ b/apps/order-service/src/app/order-workflow/infra/auth/guards/order-http-jwt.guard.ts
@@ -34,6 +34,7 @@ export class OrderHttpJwtGuard extends AuthGuard('jwt') implements CanActivate {
   constructor(
     private readonly orderRepo: OrderRepo,
     private readonly invitationRepo: WorkshopInvitationRepo,
+    private readonly reflector: Reflector
   ) {
     super();
   }

--- a/apps/order-service/src/app/order-workflow/infra/auth/guards/order-http-jwt.guard.ts
+++ b/apps/order-service/src/app/order-workflow/infra/auth/guards/order-http-jwt.guard.ts
@@ -7,6 +7,7 @@ import {
     Logger,
     UnauthorizedException,
 } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 import { assertBelongsTo } from 'apps/order-service/src/app/order-workflow/infra/auth/assertions/assert-belongs-to.assertion';
 import { OrderRepo } from 'apps/order-service/src/app/order-workflow/infra/persistence/repositories/order/order.repo';
@@ -16,7 +17,7 @@ import { ProgrammerErrorRegistry } from 'error-handling/registries/common';
 import { OrderDomainErrorRegistry } from 'error-handling/registries/order';
 import { Request } from 'express';
 
-import { ActorEntityFieldMap, ActorName } from 'auth';
+import { ActorEntityFieldMap, ActorName, ACTOR_NAMES_KEY } from 'auth';
 
 export type Principal = { actorName: ActorName; id: string };
 
@@ -34,6 +35,7 @@ export class OrderHttpJwtGuard extends AuthGuard('jwt') implements CanActivate {
     constructor(
         private readonly orderRepo: OrderRepo,
         private readonly invitationRepo: WorkshopInvitationRepo,
+        private readonly reflector: Reflector,
     ) {
         super();
     }
@@ -114,6 +116,19 @@ export class OrderHttpJwtGuard extends AuthGuard('jwt') implements CanActivate {
             throw new DomainError({
                 errorObject: OrderDomainErrorRegistry.byCode.FORBIDDEN,
                 details: { description: 'Invalid authenticated principal' },
+            });
+        }
+
+        const allowedActors = this.reflector.get<ActorName[]>(
+            ACTOR_NAMES_KEY,
+            ctx.getHandler(),
+        );
+        if (allowedActors && !allowedActors.includes(user.actorName)) {
+            throw new DomainError({
+                errorObject: OrderDomainErrorRegistry.byCode.FORBIDDEN,
+                details: {
+                    description: `Actor ${user.actorName} not permitted`,
+                },
             });
         }
 

--- a/apps/order-service/src/main.ts
+++ b/apps/order-service/src/main.ts
@@ -115,7 +115,7 @@ async function bootstrap() {
 
   // Graceful shutdown on signals
   const shutdown = async (signal: string) => {
-    console.log(`\nReceived ${signal}. Shutting down...`);
+    console.warn({message: `\nReceived ${signal}. Shutting down...}`});
     process.exit(0);
   };
 
@@ -124,6 +124,6 @@ async function bootstrap() {
 }
 
 bootstrap().catch((err) => {
-  console.error('Fatal on bootstrap:', err);
+  console.error({ message: 'Fatal on bootstrap:', err });
   process.exit(1);
 });

--- a/libs/auth/src/index.ts
+++ b/libs/auth/src/index.ts
@@ -2,3 +2,4 @@ export * from './lib/auth';
 export * from './lib/enums/actor.enum';
 export * from './lib/assertions/actor-entity-field.map';
 export * from './lib/tokens/auth-guard.token';
+export * from './lib/decorators/actor-names.decorator';

--- a/libs/auth/src/lib/decorators/actor-names.decorator.ts
+++ b/libs/auth/src/lib/decorators/actor-names.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { ActorName } from '../enums/actor.enum';
+
+export const ACTOR_NAMES_KEY = 'actorNames';
+export const ActorNames = (...actors: ActorName[]) => SetMetadata(ACTOR_NAMES_KEY, actors);


### PR DESCRIPTION
## Summary
- allow ActorNames decorator on individual route handlers
- scope OrderHttpJwtGuard actor checks to method metadata
- tag order workflow endpoints with appropriate Commissioner or Workshop roles

## Testing
- `npm test` *(fails: Cannot find module 'apps/bonus-service/...')*
- `npx nx test test-entities` *(fails: Cannot find project 'test-entities')*

------
https://chatgpt.com/codex/tasks/task_e_68bcd2d9db00832ea08c6fcb16657a82