### PR TITLE
feat: add event id generation

### DIFF
--- a/apps/bonus-service/src/app/modules/bonus-processor/application/services/bonus-event/bonus-event.service.ts
+++ b/apps/bonus-service/src/app/modules/bonus-processor/application/services/bonus-event/bonus-event.service.ts
@@ -82,6 +82,7 @@ export class BonusEventService {
 
       if (vipGained) {
         const vipGainedPayload: VipAccquiredEventV1 = {
+          eventId: randomUUID(),
           eventName: 'VipAccquired',
           accquiredAt: isoNow(),
           commissionerId: vipProfile.commissionerId,
@@ -98,6 +99,7 @@ export class BonusEventService {
 
       if (gradeChanged) {
         const gradeAttainedPayload: GradeAttainedEventV1 = {
+          eventId: randomUUID(),
           eventName: 'GradeAttained',
           attainedAt: isoNow(),
           commissionerId: vipProfile.commissionerId,

--- a/apps/order-service/src/app/order-workflow/application/services/order/order-cancel.service.ts
+++ b/apps/order-service/src/app/order-workflow/application/services/order/order-cancel.service.ts
@@ -34,6 +34,7 @@ export class OrderCancelService {
       await this.orderRepo.update(order);
 
       const eventPayload: OrderCancelledEventV1 = {
+        eventId: randomUUID(),
         eventName: 'OrderCancelled',
         orderId: order.orderId,
         cancelledBy: order.createdAt,

--- a/apps/order-service/src/app/order-workflow/application/services/order/order-confirm-completion.service.ts
+++ b/apps/order-service/src/app/order-workflow/application/services/order/order-confirm-completion.service.ts
@@ -34,6 +34,7 @@ export class OrderComfirmCompletionService {
       await this.orderRepo.update(order);
 
       const eventPayload: OrderCompletedV1 = {
+        eventId: randomUUID(),
         eventName: 'OrderCompleted',
         orderId: order.orderId,
         schemaV: 1,

--- a/apps/order-service/src/app/order-workflow/application/services/order/order-init.service.ts
+++ b/apps/order-service/src/app/order-workflow/application/services/order/order-init.service.ts
@@ -65,6 +65,7 @@ export class OrderInitService {
       await this.workshopInvitationRepo.insertMany(workshopInvitations);
 
       const eventPayload: OrderPlacedEventV1 = {
+        eventId: randomUUID(),
         eventName: 'OrderPlaced',
         commissionerId: cmd.payload.commissionerId,
         orderID: order.orderId,

--- a/apps/order-service/src/app/order-workflow/application/services/stage/stage-completion.service.ts
+++ b/apps/order-service/src/app/order-workflow/application/services/stage/stage-completion.service.ts
@@ -55,6 +55,7 @@ export class StageCompletionService {
       await this.stagesAggregateRepo.save(stages);
 
       const stageMarkedEventPayload: StageConfirmationMarkedEventV1 = {
+        eventId: randomUUID(),
         commissionerId: order.commissionerId,
 
         confirmedAt: isoNow(),
@@ -73,7 +74,8 @@ export class StageCompletionService {
       });
 
       if (stageCompleted) {
-        const stageConfirmedEventPayload: StageConfirmedEventV1 = {
+       const stageConfirmedEventPayload: StageConfirmedEventV1 = {
+          eventId: randomUUID(),
           commissionerId: order.commissionerId,
           confirmedAt: isoNow(),
           eventName: 'StageConfirmed',
@@ -95,7 +97,8 @@ export class StageCompletionService {
         order.markAsCompleted();
         await this.ordersRepo.update(order);
 
-        const allStageConfirmedEventPayload: AllStagesCompletedEventV1 = {
+       const allStageConfirmedEventPayload: AllStagesCompletedEventV1 = {
+          eventId: randomUUID(),
           commissionerId: order.commissionerId,
 
           completedAt: isoNow(),
@@ -112,7 +115,8 @@ export class StageCompletionService {
           },
         });
 
-        const oprderMarkedAsCompleted: OrderMarkedAsCompletedEventV1 = {
+       const oprderMarkedAsCompleted: OrderMarkedAsCompletedEventV1 = {
+          eventId: randomUUID(),
           eventName: 'OrderMarkedAsCompleted',
           commissionerId: order.commissionerId,
           markedAt: isoNow(),
@@ -165,8 +169,9 @@ export class StageCompletionService {
 
       await this.stagesAggregateRepo.save(stages);
 
-      const stageConfirmedEventPayload: StageConfirmedEventV1 = {
-        commissionerId: order.commissionerId,
+       const stageConfirmedEventPayload: StageConfirmedEventV1 = {
+          eventId: randomUUID(),
+          commissionerId: order.commissionerId,
         confirmedAt: isoNow(),
         eventName: 'StageConfirmed',
         orderID: order.orderId,
@@ -187,7 +192,8 @@ export class StageCompletionService {
 
         await this.ordersRepo.update(order);
 
-        const allStagedCompletedEventPayload: AllStagesCompletedEventV1 = {
+       const allStagedCompletedEventPayload: AllStagesCompletedEventV1 = {
+          eventId: randomUUID(),
           commissionerId: order.commissionerId,
           completedAt: isoNow(),
           schemaV: 1,
@@ -203,7 +209,8 @@ export class StageCompletionService {
           },
         });
 
-        const oprderMarkedAsCompleted: OrderMarkedAsCompletedEventV1 = {
+       const oprderMarkedAsCompleted: OrderMarkedAsCompletedEventV1 = {
+          eventId: randomUUID(),
           eventName: 'OrderMarkedAsCompleted',
           commissionerId: order.commissionerId,
           markedAt: isoNow(),

--- a/apps/order-service/src/app/order-workflow/application/services/workshop/workshop-invitation-response.service.ts
+++ b/apps/order-service/src/app/order-workflow/application/services/workshop/workshop-invitation-response.service.ts
@@ -71,6 +71,7 @@ export class WorkshopInvitationResponseService {
       await this.workshopInvitationsRepo.update(workshopInvitation);
 
       const eventPayload: InvitationAcceptedEventV1 = {
+        eventId: randomUUID(),
         commissionerId: order.commissionerId,
         eventName: 'InvitationAccepted',
         acceptedAt: isoNow(),
@@ -111,6 +112,7 @@ export class WorkshopInvitationResponseService {
       await this.orderRepo.update(order);
 
       const eventPayload: InvitationConfirmedEventV1 = {
+        eventId: randomUUID(),
         commissionerId: order.commissionerId,
         eventName: 'InvitationConfirmed',
         confirmedAt: isoNow(),
@@ -158,6 +160,7 @@ export class WorkshopInvitationResponseService {
       await this.orderRepo.update(order);
 
       const eventPayload: InvitationDeclinedEventV1 = {
+        eventId: randomUUID(),
         commissionerId: order.commissionerId,
         eventName: 'InvitationDeclined',
         declinedAt: isoNow(),

--- a/libs/contracts/src/_common/base-event.event.ts
+++ b/libs/contracts/src/_common/base-event.event.ts
@@ -1,4 +1,5 @@
 export interface BaseEvent<N extends string> {
+  eventId: string;
   eventName: N;
   schemaV: number;
 }

--- a/libs/contracts/src/bonus-service/events/grade-attained.event.ts
+++ b/libs/contracts/src/bonus-service/events/grade-attained.event.ts
@@ -8,6 +8,10 @@ export class GradeAttainedEventV1 implements BaseEvent<'GradeAttained'> {
 
   @IsString()
   @IsNotEmpty()
+  eventId!: string;
+
+  @IsString()
+  @IsNotEmpty()
   commissionerId!: string;
 
   @IsString()

--- a/libs/contracts/src/bonus-service/events/vip-accquired.event.ts
+++ b/libs/contracts/src/bonus-service/events/vip-accquired.event.ts
@@ -8,6 +8,10 @@ export class VipAccquiredEventV1 implements BaseEvent<'VipAccquired'> {
 
   @IsString()
   @IsNotEmpty()
+  eventId!: string;
+
+  @IsString()
+  @IsNotEmpty()
   commissionerId!: string;
 
   @Equals(1)

--- a/libs/contracts/src/bonus-service/events/vip-lost.event.ts
+++ b/libs/contracts/src/bonus-service/events/vip-lost.event.ts
@@ -8,6 +8,10 @@ export class VipLostEventV1 implements BaseEvent<'VipLost'> {
 
   @IsString()
   @IsNotEmpty()
+  eventId!: string;
+
+  @IsString()
+  @IsNotEmpty()
   commissionerId!: string;
 
   @Equals(1)

--- a/libs/contracts/src/order-service/events/all-invitations-declined.event.ts
+++ b/libs/contracts/src/order-service/events/all-invitations-declined.event.ts
@@ -13,6 +13,11 @@ export class AllInvitationsDeclinedEventV1
   @ApiProperty({ type: String })
   @IsString()
   @IsNotEmpty()
+  eventId!: string;
+
+  @ApiProperty({ type: String })
+  @IsString()
+  @IsNotEmpty()
   orderID!: string;
 
   @ApiProperty({ type: String })

--- a/libs/contracts/src/order-service/events/all-responses-received.event.ts
+++ b/libs/contracts/src/order-service/events/all-responses-received.event.ts
@@ -10,6 +10,10 @@ export class AllResponsesReceivedEventV1
 
   @IsString()
   @IsNotEmpty()
+  eventId!: string;
+
+  @IsString()
+  @IsNotEmpty()
   orderID!: string;
 
   @IsString()

--- a/libs/contracts/src/order-service/events/all-stages-completed.event.ts
+++ b/libs/contracts/src/order-service/events/all-stages-completed.event.ts
@@ -10,6 +10,10 @@ export class AllStagesCompletedEventV1
 
   @IsString()
   @IsNotEmpty()
+  eventId!: string;
+
+  @IsString()
+  @IsNotEmpty()
   orderID!: string;
 
   @IsString()

--- a/libs/contracts/src/order-service/events/cancelled.event.ts
+++ b/libs/contracts/src/order-service/events/cancelled.event.ts
@@ -14,6 +14,10 @@ export class CancelledEventV1 implements BaseEvent<'Cancelled'> {
 
   @IsString()
   @IsNotEmpty()
+  eventId!: string;
+
+  @IsString()
+  @IsNotEmpty()
   orderID!: string;
 
   @IsString()

--- a/libs/contracts/src/order-service/events/invitation-accepted.event.ts
+++ b/libs/contracts/src/order-service/events/invitation-accepted.event.ts
@@ -16,6 +16,10 @@ export class InvitationAcceptedEventV1
 
   @IsString()
   @IsNotEmpty()
+  eventId!: string;
+
+  @IsString()
+  @IsNotEmpty()
   commissionerId!: string;
 
   @IsString()

--- a/libs/contracts/src/order-service/events/invitation-confirmed.event.ts
+++ b/libs/contracts/src/order-service/events/invitation-confirmed.event.ts
@@ -16,6 +16,10 @@ export class InvitationConfirmedEventV1
 
   @IsString()
   @IsNotEmpty()
+  eventId!: string;
+
+  @IsString()
+  @IsNotEmpty()
   commissionerId!: string;
 
   @IsString()

--- a/libs/contracts/src/order-service/events/invitation-declined.event.ts
+++ b/libs/contracts/src/order-service/events/invitation-declined.event.ts
@@ -10,6 +10,10 @@ export class InvitationDeclinedEventV1
 
   @IsString()
   @IsNotEmpty()
+  eventId!: string;
+
+  @IsString()
+  @IsNotEmpty()
   commissionerId!: string;
 
   @IsString()

--- a/libs/contracts/src/order-service/events/offer-accepted.event.ts
+++ b/libs/contracts/src/order-service/events/offer-accepted.event.ts
@@ -10,6 +10,10 @@ export class WorkshopInvitationAcceptedEventV1
 
   @IsString()
   @IsNotEmpty()
+  eventId!: string;
+
+  @IsString()
+  @IsNotEmpty()
   orderID!: string;
 
   @IsString()

--- a/libs/contracts/src/order-service/events/order-cancelled.event.ts
+++ b/libs/contracts/src/order-service/events/order-cancelled.event.ts
@@ -13,6 +13,10 @@ export class OrderCancelledEventV1 implements BaseEvent<'OrderCancelled'> {
   @IsString()
   eventName!: 'OrderCancelled';
 
+  @IsString()
+  @IsNotEmpty()
+  eventId!: string;
+
   @IsNotEmpty()
   @IsString()
   orderId!: string;

--- a/libs/contracts/src/order-service/events/order-completed.event.ts
+++ b/libs/contracts/src/order-service/events/order-completed.event.ts
@@ -5,11 +5,16 @@ import {
   Equals,
   IsInt,
 } from 'class-validator';
+import { BaseEvent } from 'libs/contracts/src/_common/base-event.event';
 
-export class OrderCompletedV1 {
+export class OrderCompletedV1 implements BaseEvent<'OrderCompleted'> {
   @IsString()
   @IsNotEmpty()
   eventName!: 'OrderCompleted';
+
+  @IsString()
+  @IsNotEmpty()
+  eventId!: string;
 
   @IsString()
   @IsNotEmpty()

--- a/libs/contracts/src/order-service/events/order-marked-as-completed.event.ts
+++ b/libs/contracts/src/order-service/events/order-marked-as-completed.event.ts
@@ -16,6 +16,10 @@ export class OrderMarkedAsCompletedEventV1
 
   @IsString()
   @IsNotEmpty()
+  eventId!: string;
+
+  @IsString()
+  @IsNotEmpty()
   orderId!: string;
 
   @IsString()

--- a/libs/contracts/src/order-service/events/order-placed.event.ts
+++ b/libs/contracts/src/order-service/events/order-placed.event.ts
@@ -18,6 +18,10 @@ export class OrderPlacedEventV1 implements BaseEvent<'OrderPlaced'> {
 
   @IsString()
   @IsNotEmpty()
+  eventId!: string;
+
+  @IsString()
+  @IsNotEmpty()
   orderID!: string;
 
   @IsString()

--- a/libs/contracts/src/order-service/events/request-edeited.event.ts
+++ b/libs/contracts/src/order-service/events/request-edeited.event.ts
@@ -8,6 +8,10 @@ export class RequestEditedEventV1 implements BaseEvent<'RequestEdited'> {
 
   @IsString()
   @IsNotEmpty()
+  eventId!: string;
+
+  @IsString()
+  @IsNotEmpty()
   commissionerId!: string;
 
   @IsString()

--- a/libs/contracts/src/order-service/events/stage-confirmation-marked.event.ts
+++ b/libs/contracts/src/order-service/events/stage-confirmation-marked.event.ts
@@ -10,6 +10,10 @@ export class StageConfirmationMarkedEventV1
 
   @IsString()
   @IsNotEmpty()
+  eventId!: string;
+
+  @IsString()
+  @IsNotEmpty()
   orderID!: string;
 
   @IsString()

--- a/libs/contracts/src/order-service/events/stage-confirmed.event.ts
+++ b/libs/contracts/src/order-service/events/stage-confirmed.event.ts
@@ -8,6 +8,10 @@ export class StageConfirmedEventV1 implements BaseEvent<'StageConfirmed'> {
 
   @IsString()
   @IsNotEmpty()
+  eventId!: string;
+
+  @IsString()
+  @IsNotEmpty()
   orderID!: string;
 
   @IsString()


### PR DESCRIPTION
## Summary
- add `eventId` to `BaseEvent`
- ensure event producers generate UUIDs for `eventId`
- adjust tests for new event identifier

## Testing
- `npm test` *(fails: Cannot find module 'error-handling/error-core', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0915768ac832eb4bf048eb56459cd