### PR TITLE
refactor(contracts): make eventId part of BaseEvent interface

### DIFF
--- a/apps/bonus-service/src/app/modules/bonus-processor/adapters/inbound/messaging/kafka.consumer.ts
+++ b/apps/bonus-service/src/app/modules/bonus-processor/adapters/inbound/messaging/kafka.consumer.ts
@@ -27,8 +27,7 @@ export class BonusEventsConsumer {
     @Payload() payload: object,
     @Ctx() ctx: KafkaContext,
   ) {
-    const eventId = getHashId(payload);
-    await this.route({ ...payload, eventId }, ctx);
+    await this.route(payload, ctx);
   }
 
   @EventPattern(KafkaTopics.StageTransitions)

--- a/apps/order-service/src/app/order-workflow/infra/workshop-invitation-tracker/workshop-invitation-tracker.service.ts
+++ b/apps/order-service/src/app/order-workflow/infra/workshop-invitation-tracker/workshop-invitation-tracker.service.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'crypto';
+
 import { Injectable, Logger } from '@nestjs/common';
 import { KafkaProducerPort } from 'adapter';
 import {
@@ -60,6 +62,7 @@ export class WorkshopInvitationTracker {
       const events: OrderEventInstanceUnion[] = [];
 
       const allRes: AllResponsesReceivedEventV1 = {
+        eventId: randomUUID(),
         eventName: 'AllResponsesReceived',
         orderID: orderId,
         commissionerId: tracker.commissionerId,
@@ -70,6 +73,7 @@ export class WorkshopInvitationTracker {
 
       if (tracker.declines >= tracker.total) {
         const allDecl: AllInvitationsDeclinedEventV1 = {
+          eventId: randomUUID(),
           eventName: 'AllInvitationsDeclined',
           orderID: orderId,
           commissionerId: tracker.commissionerId,


### PR DESCRIPTION
## Summary
- add `eventId` to `BaseEvent`
- ensure event producers generate UUIDs for `eventId`
- adjust tests for new event identifier
- add eventId generation for invitation summary events
- forward existing eventId in bonus consumer

## Testing
- `npm test` *(fails: Cannot find module 'contracts')*


------
https://chatgpt.com/codex/tasks/task_e_68c0c5458768832ea57d2afe2c2c01b6