### PR TITLE
fix(bonus): preserve producer eventId in consumer

### DIFF
--- a/apps/bonus-service/src/app/modules/bonus-processor/adapters/inbound/messaging/kafka.consumer.ts
+++ b/apps/bonus-service/src/app/modules/bonus-processor/adapters/inbound/messaging/kafka.consumer.ts
@@ -27,8 +27,7 @@ export class BonusEventsConsumer {
     @Payload() payload: object,
     @Ctx() ctx: KafkaContext,
   ) {
-    const eventId = getHashId(payload);
-    await this.route({ ...payload, eventId }, ctx);
+    await this.route(payload, ctx);
   }
 
   @EventPattern(KafkaTopics.StageTransitions)


### PR DESCRIPTION
## Summary
- forward producer-provided eventId in order transition consumer

## Testing
- `npm test` *(fails: Cannot find module 'contracts', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c4f6e254832eb89daab7d4cb1d76